### PR TITLE
Installation problem on MacOSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.gem
 .bundle
 Gemfile.lock
+Makefile
 pkg/*

--- a/ext/openbabel/Makefile
+++ b/ext/openbabel/Makefile
@@ -1,8 +1,0 @@
-.PHONY: openbabel.so
-openbabel.so:
-	chmod 755 openbabel.so
-
-.PHONY: install
-install:
-	mkdir -p ../../lib/openbabel
-	mv openbabel.so ../../lib/openbabel

--- a/ext/openbabel/extconf.rb
+++ b/ext/openbabel/extconf.rb
@@ -38,6 +38,18 @@ begin
     puts `make`
   end
   FileUtils.cp(ob_bindings_dir+"/openbabel.#{RbConfig::CONFIG["DLEXT"]}", "./")
+	File.open('Makefile', 'w') do |makefile|
+		makefile.write <<"EOF"
+.PHONY: openbabel.#{RbConfig::CONFIG["DLEXT"]}
+openbabel.#{RbConfig::CONFIG["DLEXT"]}:
+	chmod 755 openbabel.#{RbConfig::CONFIG["DLEXT"]}
+
+.PHONY: install
+install:
+	mkdir -p ../../lib/openbabel
+	mv openbabel.#{RbConfig::CONFIG["DLEXT"]} ../../lib/openbabel
+EOF
+	end
 ensure
   FileUtils.remove_entry_secure main_dir
 end

--- a/openbabel.gemspec
+++ b/openbabel.gemspec
@@ -12,6 +12,6 @@ Gem::Specification.new do |s|
   s.summary = %q{OpenBabel!}
   s.test_files = ["test/test_openbabel.rb"]
 
-  s.files = ["Rakefile", "lib/openbabel.rb", "ext/openbabel/Makefile"]
+  s.files = ["Rakefile", "lib/openbabel.rb"]
   s.extensions = ['ext/openbabel/extconf.rb']
 end


### PR DESCRIPTION
Hi.

I've been using this gem package in my Linux system without any problem,
but when I tried to install it into my MacOSX system, it failed.

So I've written patches to get extconf.rb to work on MacOSX.

If you like these patches, please accept this request, or feel free to dismiss.

Thanks.
